### PR TITLE
Repoless ops

### DIFF
--- a/lib/App/GitHub.pm
+++ b/lib/App/GitHub.pm
@@ -396,6 +396,13 @@ sub _do_login {
             owner => $self->{_data}->{owner}, repo  => $self->{_data}->{repo},
             login => $self->{_data}->{login}, token => $self->{_data}->{token}
         );
+    } else {
+        # Create a Net::GitHub object with the owner set to the logged in user
+        # Super convenient if you don't want to set a user first
+        $self->{github} = Net::GitHub->new(
+            login => $self->{_data}->{login}, token => $self->{_data}->{token},
+            owner => $self->{_data}->{login}
+        );
     }
 }
 
@@ -403,7 +410,7 @@ sub run_github {
     my ( $self, $c1, $c2 ) = @_;
     
     unless ( $self->github ) {
-        $self->print(q~unknown repo. try 'repo :owner :repo' first~);
+        $self->print(q~not enough information. try calling login :user :token or repo :owner :repo first~);
         return;
     }
     


### PR DESCRIPTION
Currently, users need to call repo :repo to run pretty much every operation.

With this patch, users who logged in can instead call functions like r.list without having to set a repo first. This makes the application significantly easier to use, imo.
