### PR TITLE
Limit pager use

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,7 @@ copyright_holder = Fayland Lam
 [Prereqs]
 Net::GitHub = 0.12
 Term::ReadLine = 0
+Term::ReadKey = 0
 JSON::XS = 2.232
 Moose = 0
 IPC::Cmd = 0


### PR DESCRIPTION
The use of the pager for every print statement is unwieldy. This patch only calls the pager when it's absolutely necessary to display the entire output stream easily.
